### PR TITLE
Create POC for shade overlay and screen reader description box

### DIFF
--- a/sr-poc.html
+++ b/sr-poc.html
@@ -1,0 +1,67 @@
+<html lang="en">
+    <head>
+        <title>Inclusiville Screen Shade and Screen Reader Description Proof-of-Concept</title>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.1.3/axe.min.js"></script>
+<style>
+#content { z-index: 1; }
+#overlay {
+  z-index: 2;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0,0,0,0.5);
+}
+#sr-description {
+  z-index: 3;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  width: 20%;
+  height: 12%;
+  background-color: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  font-weight: bold;
+  text-align: left;
+  padding: 10px;
+}
+</style>
+    </head>
+    <body>
+
+<div id="content">
+    <h1>Inclusiville Screen Shade and Screen Reader Description Proof-of-Concept</h1>
+    <p> This page is overlaid with a dark grey layer that prevents mouse interaction with its content.  However, interactive elements can still be accessed with the keyboard (via the Tab and Shift+Tab keys). When an element comes into focus, its ARIA role and text should appear in the description box at the bottom right of the page, much like what happens with the VoiceOver screen reader on Mac OS X.</p>
+    <p>The Inclusiville project was started at the <a href="https://www.deque.com/axe-con/axe-hackathon/" target="new">2021 axe-hackathon (opens in new window)</a>. Tab to this link and press space or Enter to learn about this event.</p>
+    <p>
+        When it's in focus, this button displays an alert message when you press space or Enter.
+        <button onclick="alert( 'You pressed me with the keyboard');">Press me</button>
+    </p>
+    <p>
+        This button doesn't do anything, but it can be focused on using the Tab key.
+        <button>Another Button</button>
+    </p>
+    <p>
+        A next step is to override the left and right arrow keys so that they can be used to navigate through all page elements, whether or not they are interactive.
+    </p>
+</div>
+<div id="overlay"></div>
+<div id="sr-description"></div>
+
+<script>
+var axeTree = axe.utils.getFlattenedTree(document.body);
+document.querySelectorAll("#content *").forEach( e => {
+    e.addEventListener( 'focus', event => {
+        var activeElement = document.activeElement;
+        var text = axe.commons.aria.getRole(activeElement, axeTree)
+            + ": "
+            + axe.commons.text.accessibleText(activeElement, axeTree);
+        var description = document.getElementById("sr-description");
+        description.textContent = text;
+    })
+});
+</script>
+    </body>
+</html>


### PR DESCRIPTION
Open the `sr-poc.html` page and tab through the contents. They active element's ARIA role and text should display in the description box at the bottom right of the page.